### PR TITLE
Feature/#17 social login

### DIFF
--- a/src/features/Account/Login.jsx
+++ b/src/features/Account/Login.jsx
@@ -13,37 +13,21 @@ const Login = ({ onClose }) => {
   const [showJoin, setShowJoin] = useState(false);
 
   // 구글 로그인
-  const handleGoogleLogin = useCallback(async () => {
-    try {
-      // 구글 로그인 API 호출
-      const res = await fetch('/api/auth/google', { method: 'POST' });
-      const data = await res.json();
-      console.log('Google login success', data);
-      onClose();
-    } catch (err) {
-      console.error('Google login failed', err);
-    }
-  }, [onClose]);
+  const handleGoogleLogin = useCallback(() => {
+    window.location.href = `${import.meta.env.VITE_API_URL}/auth/login/google`;
+  }, []);
 
   // 카카오 로그인
-  const handleKakaoLogin = useCallback(async () => {
-    try {
-      // 카카오 로그인 API 호출
-      const res = await fetch('/api/auth/kakao', { method: 'POST' });
-      const data = await res.json();
-      console.log('Kakao login success', data);
-      onClose();
-    } catch (err) {
-      console.error('Kakao login failed', err);
-    }
-  }, [onClose]);
+  const handleKakaoLogin = useCallback(() => {
+    window.location.href = `${import.meta.env.VITE_API_URL}/auth/login/kakao`;
+  }, []);
 
   // 이메일 로그인 버튼 클릭 → 가입 모드 활성화
   const handleEmailClick = useCallback(() => {
     setShowJoin(true);
   }, []);
 
-  // Join 컴포넌트에서 “뒤로” 또는 완료 후 돌아올 때 호출할 핸들러
+  // Join 컴포넌트에서 "뒤로" 또는 완료 후 돌아올 때 호출할 핸들러
   const handleJoinBack = useCallback(() => {
     setShowJoin(false);
   }, []);
@@ -77,12 +61,12 @@ const Login = ({ onClose }) => {
       </div>
 
       <div className={styles.methods}>
-        <button className={`${styles.methodButton} ${styles.google}`}>
+        <button className={`${styles.methodButton} ${styles.google}`} onClick={handleGoogleLogin}>
           <img className={styles.icon} src={googleIcon} alt="Google Logo" />
           <span>Continue with Google</span>
         </button>
 
-        <button className={`${styles.methodButton} ${styles.kakao}`}>
+        <button className={`${styles.methodButton} ${styles.kakao}`} onClick={handleKakaoLogin}>
           <img className={styles.icon} src={kakaoIcon} alt="Kakao Logo" />
           <span>카카오 로그인</span>
         </button>

--- a/src/features/Account/Login.jsx
+++ b/src/features/Account/Login.jsx
@@ -14,12 +14,18 @@ const Login = ({ onClose }) => {
 
   // 구글 로그인
   const handleGoogleLogin = useCallback(() => {
-    window.location.href = `${import.meta.env.VITE_API_URL}/auth/login/google`;
+    console.log('API URL:', import.meta.env.VITE_API_URL); // 환경변수 확인
+    const redirectUrl = `${import.meta.env.VITE_API_URL}/api/auth/login/google`;
+    console.log('Redirecting to:', redirectUrl); // 리다이렉트 URL 확인
+    window.location.href = redirectUrl;
   }, []);
 
   // 카카오 로그인
   const handleKakaoLogin = useCallback(() => {
-    window.location.href = `${import.meta.env.VITE_API_URL}/auth/login/kakao`;
+    console.log('API URL:', import.meta.env.VITE_API_URL); // 환경변수 확인
+    const redirectUrl = `${import.meta.env.VITE_API_URL}/api/auth/login/kakao`;
+    console.log('Redirecting to:', redirectUrl); // 리다이렉트 URL 확인
+    window.location.href = redirectUrl;
   }, []);
 
   // 이메일 로그인 버튼 클릭 → 가입 모드 활성화


### PR DESCRIPTION
## #️⃣연관된 이슈

> #17 
## 📝작업 내용

> 소셜로그인 연동 완료했습니다.
> passport사용해서 이전에 소셜로그인했던 사용자는 승인화면 없이 자동으로 로그인처리 됩니다. --> 간편함
> 소셜로그인하면 홈화면으로 자동 리다이렉트됩니다.
> 리다이렉트하면 url 끝에 token=블라블라 이런식으로 토큰 볼 수 있습니다. (jwt토큰임)
> 토큰은 socialLogins테이블에 저장됩니다.

### 스크린샷 (선택)
<img width="836" alt="image" src="https://github.com/user-attachments/assets/5d4cbacd-f40b-4ca6-a107-1d10e97095d1" />
<img width="472" alt="image" src="https://github.com/user-attachments/assets/cf707cfa-92b0-4922-b666-b931ccd158d0" />
받아올 수 있는 것들은 모두 받아왔습니다. (2번은 학교 구글계정으로 테스트한거라 개인정보를 입력 안 해둬서 없음)
카카오는 모든 사용자의 로그인을 허락하면서 정보를 받아오려면 한계가 있었습니다.



## 💬리뷰 요구사항(선택)

> 자동으로 불러오지 못하는 정보들을 사용자가 원할 경우 마이페이지에서 수정하는 걸로 하면 어떨까요?
