### PR TITLE
Feat : 장소 이미지 api 연결 및 루트 이미지 업로드 api 연결 

### DIFF
--- a/src/components/MakeRoute/PlaceHeader.jsx
+++ b/src/components/MakeRoute/PlaceHeader.jsx
@@ -1,16 +1,32 @@
 import styles from './PlaceHeader.module.css';
-
 import Title from '../common/Title/Title';
 import BookMark from '../Button/BookMark';
 
-const PlaceHeader = ( { place }) => {
+const PlaceHeader = ({ place }) => {
+  //console.log('[PlaceHeader]', place.thumbnail_url);
+  
+
   return (
     <div className={styles.headerContainer}>
-      <img className={styles.thumbnail} src="src/assets/mock/thumb.jpg" alt="썸네일" />
+      <img
+        className={styles.thumbnail}
+          src={place.thumbnail_url || '/src/assets/mock/thumb.jpg'}
+          alt="썸네일"
+          loading="lazy"
+          referrerPolicy="no-referrer" //	Google CDN이 Referrer 헤더를 검사해서 거부하는 경우 방지
+          onError={(e) => {
+              console.warn('[PlaceHeader] 이미지 로드 실패:', place?.thumbnail_url);
+              e.target.onerror = null; // 무한루프 방지
+              e.target.src = '/src/assets/mock/thumb.jpg'; // 실패 시 기본 이미지로 대체
+            }} 
+      />
+
       <div className={styles.headerContent}>
         <div className={styles.titleBlock}>
           <Title text={place.place_name || '장소 이름 없음'} />
-          <div className={styles.categoryRating}> {place.bizCategory || '카테고리 없음'} ★ {"!!! 장소 별점 연동 !!!"}</div>
+          <div className={styles.categoryRating}>
+            {place.bizCategory || '카테고리 없음'} ★ {place.point || '0.0'}
+          </div>
         </div>
         <BookMark type="place" />
       </div>

--- a/src/components/MakeRoute/RouteHeader.jsx
+++ b/src/components/MakeRoute/RouteHeader.jsx
@@ -1,13 +1,62 @@
+// RouteHeader.jsx
+import { useRef } from 'react';
 import styles from '../../features/LeftBar/MakeRoute/MakeRoutePopup.module.css';
 
-const RouteHeader = () => (
-  <div className={styles.routeHeader}>
-    <img className={styles.thumbnail} src="src/assets/mock/thumb.jpg" alt="썸네일" />
-    <b className={styles.routeTitle}>Name of Route</b>
-    <div className={styles.routeSubtext}>with Friend
-      장문 테스트 장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트장문 테스트
+const RouteHeader = ({ imageUrl, onImageUpload }) => {
+  const fileInputRef = useRef(null);
+
+  const handleClick = () => {
+  console.log('[RouteHeader] 썸네일 클릭됨');
+  if (fileInputRef.current) {
+    fileInputRef.current.value = ''; // 👈 선택값 초기화
+    fileInputRef.current.click();    // 👈 파일 선택창 열기
+  }
+};
+
+ const handleChange = (e) => {
+  console.log('[RouteHeader] 파일 선택 변경 감지');
+
+  const fileList = e.target.files;
+  console.log('[RouteHeader] 선택된 파일들:', fileList);
+
+  const file = fileList?.[0];
+  if (!file) {
+    console.warn('[RouteHeader] 파일이 없습니다.');
+    return;
+  }
+
+  console.log('[RouteHeader] 전달할 파일:', file);
+
+  if (onImageUpload) {
+    onImageUpload(file);
+  }
+};
+
+  return (
+    <div className={styles.routeHeader}>
+      <input
+        type="file"
+        accept="image/*"
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+        onChange={handleChange}
+      />
+      <img
+        className={styles.thumbnail}
+        src={imageUrl || 'src/assets/mock/thumb.jpg'}
+        alt="썸네일"
+        onClick={handleClick} //썸네일 클릭 가능
+        onError={(e) => {
+          e.target.onerror = null;
+          e.target.src = 'src/assets/mock/thumb.jpg';
+        }}
+      />
+      <b className={styles.routeTitle}>Name of Route</b>
+      <div className={styles.routeSubtext}>
+        with Friend 장문 테스트 장문 테스트 장문 테스트 ...
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default RouteHeader;

--- a/src/features/LeftBar/MakeRoute/MakeRoutePopup.jsx
+++ b/src/features/LeftBar/MakeRoute/MakeRoutePopup.jsx
@@ -14,6 +14,7 @@ const MakeRoutePopup = () => {
   const [searchParams] = useSearchParams();
   const placeId = searchParams.get('placeId'); 
   const [routePlaces, setRoutePlaces] = useState([]);
+  const [routeImageUrl, setRouteImageUrl] = useState(null); //루트 이미지 상태
 
   const handleAddPlace = async () => {
     if (!placeId) return;
@@ -35,10 +36,29 @@ const MakeRoutePopup = () => {
     }
   }; 
 
+  //이미지 업로드 핸들러
+  const handleImageUpload = async (file) => {
+    if (!file) return;// 파일 아니면 작동 x 
+
+    const formData = new FormData();
+    formData.append('image', file);
+    console.log('[MakeRoutePopup] 이미지 업로드 요청 중...');
+
+    try {
+      const res = await axios.post(`${VITE_BASE_URL}/api/upload/image`, formData);//이미지 업로드 api 연결
+      const uploadedUrl = res.data.url;
+      setRouteImageUrl(uploadedUrl); //받아온 이미지 url 저장하기
+      console.log('[MakeRoutePopup] 업로드된 이미지 URL:', uploadedUrl);
+      // 이 URL을 루트 생성 시 서버로 함께 전송하면 됩니다
+    } catch (err) {
+      console.error('❌ 이미지 업로드 실패:', err);
+    }
+  };
+
   return (
     <div className={styles.route}>
       <div className={styles.scroll}>
-        <RouteHeader />
+        <RouteHeader imageUrl={routeImageUrl} onImageUpload={handleImageUpload} /> {/*루트 이미지 띄우기기 */}
         {routePlaces.map((place, idx) => (
           <RouteStepCard
             key={place.place_id}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #66  (루트 이미지 api는 이슈 안 달아놓음) 

## 📝작업 내용

> 장소 이미지 api 연결 및 루트 이미지 api 연결을 진행했습니다 

**1. 장소 검색 시 이미지 API 연동**

- 장소 추가 시 thumbnail_url을 서버에 함께 전송하도록 구현
- 장소 이미지가 정상적으로 렌더링되도록 프론트엔드 적용


**2. 루트 이미지 업로드 기능 추가**

- 사용자가 썸네일 클릭 시 이미지 파일 업로드 가능하도록 UI 및 기능 구현
- 이미지 업로드 시 서버에 전송하고, 반환된 URL을 루트 대표 이미지로 저장하도록 처리
- 사용자가 이미지를 업로드하지 않은 경우, 첫 번째 장소의 이미지를 루트 대표 이미지로 자동 설정


### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/99febf49-d7bd-4f2f-b789-9f8ea5800216)
![image](https://github.com/user-attachments/assets/0b2224b5-af38-47a5-82c2-94033fc9241d)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요