### PR TITLE
Feat: 경유 검색 api 연결 

### DIFF
--- a/src/components/HottestRoute/HottestRoute.jsx
+++ b/src/components/HottestRoute/HottestRoute.jsx
@@ -59,7 +59,7 @@ const HottestRoute = ({ onMoreClick = () => {}, onRouteSelect = () => {} }) => {
             key={route.routeId}
             className={styles.routeItem}
             onClick={() => {
-                console.log('클릭한 route:', route);        
+                //console.log('클릭한 route:', route);        
                 //onRouteSelect(route)
                 setSelectedRoute(route)}
               } // 클릭 시 팝업용 상태에 route 저장

--- a/src/features/LeftBar/SearchingRoute/SearchingRoutePopup.jsx
+++ b/src/features/LeftBar/SearchingRoute/SearchingRoutePopup.jsx
@@ -48,20 +48,34 @@ const SearchingRoutePopup = ({ routeId, onClose }) => {
   if (!routeData) return <div>Loading...</div>;
 
   
-  //경유 검색 api 연동 (기본적인 틀은 경로 똑같습니다)
-  const handleSearchRoute = async () => {
-  if (!routeData || routeData.places.length < 3) return;
+  //경유 검색 api 연동 (기본적인 틀은 경로 검색이랑 똑같습니다다)
+ const handleSearchRoute = async () => {
+  if (!routeData || !Array.isArray(routeData.places)) return;
 
-  const originName = routeData.places[0]?.name;
-  const waypointName = routeData.places[1]?.name;
-  const destinationName = routeData.places[2]?.name;
+  const places = routeData.places;
+  let originName, destinationName, waypointName;
+
+  // 장소가 2개일 경우엔 출발지 - 목적지
+  if (places.length === 2) {
+    originName = places[0]?.name;
+    destinationName = places[1]?.name;
+  }
+  // 장소가 3개일 경우엔 출발지 - 경유지 - 목적지
+  else if (places.length === 3) {
+    originName = places[0]?.name;
+    waypointName = places[1]?.name;
+    destinationName = places[2]?.name;
+  } else {
+    console.warn('장소 개수가 2개 또는 3개가 아닙니다.');//일단 장소 1개면 경로 검색 못하게 막아놓기 
+    return;
+  }
 
   try {
     const response = await axios.get(`${VITE_BASE_URL}/api/maps`, {
       params: {
         originName,
         destinationName,
-        waypointName,
+        ...(waypointName ? { waypointName } : {}), // 경유지 있을 때만 포함
       },
     });
 
@@ -83,6 +97,7 @@ const SearchingRoutePopup = ({ routeId, onClose }) => {
     console.error('경로 검색 실패:', err);
   }
 };
+
 
 
 
@@ -112,7 +127,7 @@ const SearchingRoutePopup = ({ routeId, onClose }) => {
           />
         ))}
         <SearchingRoad isEnabled onSearchClick={handleSearchRoute} />
-        <TransportModes routeData={routes} /> {/*여기에 경로 검색 연동*/}
+        <TransportModes routeData={routes} /> 
         <RatingCard
           averageRating={routeData.avgRates}
           userRating={0}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #104 

## 📝작업 내용

> 루트 상세 팝업(SearchingRoutePopup)에서 장소 개수에 따라 경로 검색 방식이 달라지도록 개발했습니다.  일단은 경유지 3개인 것만 가정하고 만들었어습니다 (경유지 많아지는 건 추후 작업해볼게여)

### 주요 변경 사항
- `routeData.places.length === 2`일 경우:
  - 출발지: place[0]
  - 목적지: place[1]
  - → 기본 경로 검색 API 호출 (`originName`, `destinationName`)

- `routeData.places.length === 3`일 경우:
  - 출발지: place[0]
  - 경유지: place[1]
  - 목적지: place[2]
  - → 경유 포함 경로 검색 API 호출 (`originName`, `destinationName`, `waypointName`)

- 경로 검색 결과(`routes`) 초기화 로직 추가
  - `routeId`가 바뀔 때 기존 경로 결과 초기화 (`setRoutes([])`)

- API 응답 결과를 기반으로 `TransportModes` 컴포넌트에 경로 리스트 전달
  - 클릭 시 지도에 polyline 반영됨 (`localStorage + polylineChanged 이벤트` 활용)

### 테스트 방법
1. 루트 상세 팝업에서 장소가 2개인 루트를 클릭 → 출발-도착 경로 검색 확인
2. 장소가 3개인 루트를 클릭 → 경유 포함 경로 검색 확인
3. 다른 루트로 전환 시 이전 경로 결과가 초기화되는지 확인


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fd36673e-ebe7-468f-ac05-0ac60dd535f6)
<img width="610" alt="image" src="https://github.com/user-attachments/assets/bfb0ee81-de18-400c-a07e-50bb0c821d0d" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
